### PR TITLE
增加指数模型估计

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -231,24 +231,20 @@ app_server <- function( input, output, session ) {
     lm6 <- lm(y~x)
     residuals <- rstudent(lm6)
     dwelling <- ts(residuals)
-    adf<-adf.test(dwelling,nlag = 2)
-    adf_p_value <- min(adf$type1[1,3], adf$type1[2,3], adf$type2[1,3], 
-                       adf$type2[2,3], adf$type3[1,3], adf$type3[2,3])
-    fit <- stats::arima(dwelling, order=c(1, 0, 0))
-    fore <- forecast::forecast(fit,  h=5)
-    fore1 <- as.data.frame(fore)
-    fore2 <- as.data.frame(fore$fitted)
-    stringadf<-paste("time  ", "(", "ADF p_value:",adf_p_value, ")")
-    p <- ggplot(fore1,
-                aes(x=as.numeric(row.names(fore1)), y=fore1$"Point Forecast"))+ 
-      labs(x=stringadf,y="residuals")+ geom_point(color="blue")+ 
-      geom_smooth(data=fore1, aes(x=as.numeric(row.names(fore1), 
-                                               y=fore1$"Point Forecast")), 
-                  se=FALSE, colour="blue")+
-      geom_smooth(data=dwelling,
-                  aes(x=x, y=residuals), se=FALSE, colour="black")+
-      geom_smooth(data=fore2, 
-                  aes(x=as.numeric(row.names(fore2)), y=x), se=FALSE)
+    print(dwelling)
+    if (input$fmethod == "ARIMA") {
+      p<- dwelling %>% forecast::auto.arima() %>% forecast::forecast(
+        as.numeric(input$hstep)) %>% autoplot(
+          xlab = "Year", ylab = "residuals"
+        )
+    }
+    if (input$fmethod == "ETS") {
+      
+      p<- dwelling %>% forecast::ets() %>% forecast::forecast(
+        as.numeric(input$hstep)) %>% autoplot(
+          xlab = "Year", ylab = "residuals"
+        )
+    }
     print(p)
   })
   output$Summary <- renderTable({  

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -83,6 +83,10 @@ app_ui <- function(request) {
                               box(plotOutput("distPlot5"), width=4),
                               box(plotOutput("distPlot6", 
                                              height=500), width=10),
+                              selectInput("fmethod", "method:", 
+                                          c("ETS", "ARIMA")),
+                              textInput("hstep", 
+                                        "h:", value="1"),
                       )
                     )
                   )


### PR DESCRIPTION
亲爱的余老师，您好！
启发：指数模型和ARIMA模型都是预测时间序列的主流方法。虽然线性指数平滑模型其实都是 ARIMA 模型的特例，但是非线性的指数平滑模型在 ARIMA 模型中并没有对应的部分。另一方面，也有很多 ARIMA 模型不包含指数平滑的部分。二者还有一个重要区别：所有指数平滑模型都是非平稳的，而有些ARIMA模型是平稳的。所以我们可以选择这两种模型来进行估计，并且只需要选择指数模型或者ARIMA模型即可，具体到指数模型中的哪一个，ARIMA模型中的哪一个，可以通过函数自动选择最适模型。
 1.这次更新增加了指数模型，模型包括，具有加性误差的简单指数平滑：ETS（A，N，N），具有乘性误差的简单指数平滑：ETS（M，N，N），具有加性误差的Holt线性方法：ETS（A，A，N），具有乘性误差的Holt线性方法：ETS（M，A，N）以及ETS的其他模型。
  2.用户可以通过选择这两个模型来进行方差的估计预测。
[代码运行.pdf](https://github.com/YuLab-SMU/shinyTempSignal/files/8032453/default.pdf)

